### PR TITLE
Quick Install Script

### DIFF
--- a/wptest-cli-install.sh
+++ b/wptest-cli-install.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+#
+# wptest.io Quick Install Script
+# http://wptest.io/
+#
+# Note: This script assumes you have wp-cli installed.
+##########################################################
+
+# Get WordPress Path
+printf "Please provide the local path to your WordPress install: "
+read WPPATH
+
+# Import WP TESTS
+cd $WPPATH
+curl -O https://raw.github.com/manovotny/wptest/master/wptest.xml
+wp import wptest.xml --authors=create
+rm wptest.xml


### PR DESCRIPTION
Thought this could be useful for others. Its a quick install script that can be used if the user has wp-cli installed. Addresses the issue #18 which I had created from before. This could easily be expanded on, for example to actually check and provider error if wp-cli is not installed. 
