### PR TITLE
Fixes URL in wptest-cli-install.sh

### DIFF
--- a/wptest-cli-install.sh
+++ b/wptest-cli-install.sh
@@ -12,6 +12,6 @@ read WPPATH
 
 # Import WP TESTS
 cd $WPPATH
-curl -O https://github.com/manovotny/wptest/raw/master/wptest.xml
+curl -O https://raw.githubusercontent.com/manovotny/wptest/master/wptest.xml
 wp import wptest.xml --authors=create
 rm wptest.xml


### PR DESCRIPTION
Fixed the URL for the bash/shell to pull the right file contents. Fixes "not a valid WXR file" error when trying to run the script. Fixes #31
